### PR TITLE
Cursor.Observe() 'removed' event are not firing

### DIFF
--- a/src/Collection.js
+++ b/src/Collection.js
@@ -16,13 +16,14 @@ export const runObservers = (type, collection, newDocument, oldDocument) => {
         if (
           Data.db[collection].findOne({
             $and: [{ _id: newDocument._id }, cursor._selector],
-          })
-        ) {
+          }) && type !== 'removed') {
           try {
             callbacks[type](newDocument, oldDocument);
           } catch (e) {
             console.error('Error in observe callback', e);
           }
+        }else{
+          callbacks['removed'](newDocument);
         }
       }
     });


### PR DESCRIPTION
I found that the 'removed' event in Cursor.Observe() are not firing, I guess its because 
`Data.db[collection].findOne({$and:[{_id:newDocument._id}, cursor._selector]})` returns null for deleted documents, maybe you can find a better solution than mine, thank you.